### PR TITLE
gat: Support for CentOS in getArch

### DIFF
--- a/gat/plugin.py
+++ b/gat/plugin.py
@@ -2406,12 +2406,15 @@ def dockerForceNetwork(env, name):
 
 
 def getArch(env):
+    os = env.remoteOs
     arch = None
 
-    if env.remoteOs == 'ubuntu':
+    if os == 'ubuntu':
         arch = env.runOutput("dpkg --print-architecture").strip()
-    if env.remoteOs == 'centos':
+    elif os == 'centos':
         arch = env.runOutput("uname -m").strip()
+    else:
+        raise Exception("Unsupported Operating System")
 
     return arch
 

--- a/gat/plugin.py
+++ b/gat/plugin.py
@@ -2406,7 +2406,13 @@ def dockerForceNetwork(env, name):
 
 
 def getArch(env):
-    arch = env.runOutput("dpkg --print-architecture").strip()
+    arch = None
+
+    if env.remoteOs == 'ubuntu':
+        arch = env.runOutput("dpkg --print-architecture").strip()
+    if env.remoteOs == 'centos':
+        arch = env.runOutput("uname -m").strip()
+
     return arch
 
 


### PR DESCRIPTION
gat으로 도커 설치하는 과정에서 명령어 관련 오류를 발견습니다.
찾아본 결과, getArch()에서 ubuntu만 지원하고 있어서 아래의 코드와 같이 centos에서도 지원하도록 수정했습니다.