### PR TITLE
plugin: getArch - Fix OS == None

### DIFF
--- a/gat/plugin.py
+++ b/gat/plugin.py
@@ -2409,7 +2409,7 @@ def getArch(env):
     os = env.remoteOs
     arch = None
 
-    if os == 'ubuntu':
+    if os == 'ubuntu' or os == None:
         arch = env.runOutput("dpkg --print-architecture").strip()
     elif os == 'centos':
         arch = env.runOutput("uname -m").strip()


### PR DESCRIPTION
docker connection을 진행하는 과정에서 Tasks객체가 새로 생성되는데 이 과정에서 os에 대한 정보가 소실되는 현상이 발생했습니다.
하지만 도커 내부에선 ubuntu로 작동하기 때문에 os에 대한 값이 비어있을 경우 ubuntu와 비슷하게 로직을 처리하도록 했습니다.